### PR TITLE
Fixed RAP transition

### DIFF
--- a/src/SECDMachine/VM.hs
+++ b/src/SECDMachine/VM.hs
@@ -117,10 +117,10 @@ exec (SECD ((Closure c' e'):args:s) e (AP:c) d) = Continue $ SECD [] (extendEnv 
 
 -- recursive function application (letrec)
 exec (SECD s e (DUM:c) d) = Continue $ SECD s ([]:e) c d
-exec (SECD ((Closure c' e'):bs:s) ([]:e) (RAP:c) d) = Continue $ SECD [] recEnv c' ((s,e,c):d)
-    where recEnv = (map bind bindings) : recEnv
-          bind (Closure c ([]:_)) = Closure c recEnv
-          bindings = cons2list bs
+exec (SECD ((Closure c' e'):bs:s) ([]:e) (RAP:c) d) = Continue $ SECD [] (recBindings:e) c' ((s,e,c):d)
+    where recBindings = map bind (cons2list bs)
+          bind (Closure c ([]:e)) = Closure c (recBindings:e)
+          bind x = x
 
 -- return from function and leave result on top of stack
 exec (SECD (res:_) e' (RTN:_) ((s,e,c):d)) = Continue $ SECD (res:s) e c d


### PR DESCRIPTION
#### Issue

The recursive environment created by the RAP transition is wrong: given the arguments list
`[Closure [**] [[]:e']]`
the final environment is
`[Closure [**] [Closure [**] [...], Closure [**] [...], ...], Closure [**] [...], ...]`
instead of
`[Closure [**] [Closure [**], [Closure [**] [...], e], e], e]`

Moreover the pattern of the function `bind` is not exhaustive because it matches closures only: given the argument list
`[Closure [**] [[]:e']], Num 0]`
the pattern wont match the value `Num 0`
#### Example 1
###### LiskKit Code

```
letrec
    X = 5 
    FACT = lambda ( Y ) if eq ( Y, 0 ) then 1 else Y*FACT(Y-1)
in
    FACT(X)
end
```
###### SECD Code

```
[DUM,NIL,LDF [LDC 0,LD (0,0),EQL,SEL [LDC 1,JOIN] [NIL,LD (0,0),LDC 1,SUB,CONS,LD (1,1),AP,LD (0,0),MUL,JOIN],RTN],CONS,LDC 5,CONS,LDF [NIL,LD (0,0),CONS,LD (0,1),AP,RTN],RAP,STOP]
```

As described above, this example raise a Non-exhaustive patterns exception
#### Example 2
###### LiskKit Code

```
let
   X = 5
in
  letrec
      ID = lambda ( X ) X
  in
      X
  end
end
```
###### SECD Code

```
[NIL,LDC 5,CONS,LDF [DUM,NIL,LDF [LD (0,0),RTN],CONS,LDF [LD (1,0),RTN],RAP,RTN],AP,STOP]
```

In the inner body you are supposed to load X using LD (1,0) (previous activation record, first binding). However, since the environment is in the form described above, this program returns the closure ID.
#### Solution

The solution consist in:
- Creating the environment by removing the dummy record and inserting the recursive binders. In this way the following activation records are not modified and the outer blocks variables are still accessible.
- Adding a new pattern to the function bind to match any other constructor, which does not modify the value.
